### PR TITLE
Fix: wrong filtered gene count in 01_input_qc.html

### DIFF
--- a/inst/Rmd/single_sample/01_input_qc_children/gene_filtering_custom.Rmd
+++ b/inst/Rmd/single_sample/01_input_qc_children/gene_filtering_custom.Rmd
@@ -11,7 +11,7 @@ janitor::tabyl(sce_custom_filter_rowSums == 0) %>%
   scdrake::render_bootstrap_table(full_width = FALSE, position = "left")
 ```
 
-**Removing `r sum(!drake::readd(sce_qc_gene_filter, path = drake_cache_dir))` genes with UMI per cell less than
+**Removing `r sum(drake::readd(sce_qc_gene_filter, path = drake_cache_dir))` genes with UMI per cell less than
 `r cfg$MIN_UMI` and expressed in less than `r cfg$MIN_RATIO_CELLS * 100` % of all cells.**
 
 Info on custom filtered dataset:

--- a/inst/Rmd/single_sample/01_input_qc_children/gene_filtering_qc.Rmd
+++ b/inst/Rmd/single_sample/01_input_qc_children/gene_filtering_qc.Rmd
@@ -10,7 +10,7 @@ janitor::tabyl(sce_qc_filter_rowSums == 0) %>%
   scdrake::render_bootstrap_table(full_width = FALSE, position = "left")
 ```
 
-**Removing `r sum(!drake::readd(sce_qc_gene_filter, path = drake_cache_dir))` genes with UMI per cell less than
+**Removing `r sum(drake::readd(sce_qc_gene_filter, path = drake_cache_dir))` genes with UMI per cell less than
 `r cfg$MIN_UMI` and expressed in less than `r cfg$MIN_RATIO_CELLS * 100` % of all cells.**
 
 Info on filtered dataset:


### PR DESCRIPTION
## **Description**
In the Gene filtering section of the generated _01_input_qc.html_ report, it reports a wrong number of removed filtered genes, both in custom and data-sensitive tab.
## **Current behaviour**
It reports the number of genes that aren't discarded.
## **Expected behaviour**
It should report the number of genes that are discarded and removed from the rest of the analysis.
## **Fix**
The error is in` inst/Rmd/single_sample/01_input_qc_children/gene_filtering_qc.Rmd `and `inst/Rmd/single_sample/01_input_qc_children/gene_filtering_custom.Rmd`. Example:
https://github.com/bioinfocz/scdrake/blob/d92f86e8af97b4668b2be44118734e83c1ab68bd/inst/Rmd/single_sample/01_input_qc_children/gene_filtering_qc.Rmd#L13-L14

`sce_qc_gene_filter` is a logical vector where `TRUE` is not passing the filter, and `FALSE` is passing the filter. However, currently it is summing all `FALSE` values = all the genes that are passing the filter. It is taking a reverse values of logical vector and summing it. The fix is removing the inversion of the logical vector.
